### PR TITLE
Fixed typo in var array

### DIFF
--- a/prework-study-guide/assets/script.js
+++ b/prework-study-guide/assets/script.js
@@ -1,4 +1,4 @@
-var topics = ['HTML', 'CSS', 'Git', 'Javascript'];
+var topics = ['HTML', 'CSS', 'Git', 'JavaScript'];
 var randomTopic = topics[Math.floor(Math.random() * topics.length)];
 function listTopics() {
   for(var x = 0; x < topics.length; x++) {


### PR DESCRIPTION
In the variable array of the script.js file, JavaScript was written as "Javascript" so the list function never ran it. Fixed the typo and now "Let's study JavaScript!" is an available option. 